### PR TITLE
Update README to reflect EdgeNet code as well

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,7 @@ Our main initiative is the [Sorbonne IP Route Survey (IPRS)](https://iprs.dioptr
 
 This organization hosts our primary development work. We welcome you to explore our public repositories and reach out if you're interested in contributing.
 
-## Our Research Publication Code
+## Publication-Related Code
 
 Below you'll find code repositories associated with our published research:
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,7 @@ Our main initiative is the [Sorbonne IP Route Survey (IPRS)](https://iprs.dioptr
 
 This organization hosts our primary development work. We welcome you to explore our public repositories and reach out if you're interested in contributing.
 
-## Research Code & Publications
+## Our Research Publication Code
 
 Below you'll find code repositories associated with our published research:
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -25,6 +25,6 @@ Our paper *[Zeph & Iris map the internet: A resilient reinforcement learning app
 
 ### EdgeNet (IEEE Access 2023)
 
-Our paper *[Multitenant Containers as a Service (CaaS) for Clouds and Edge Clouds](https://doi.org/10.1109/ACCESS.2023.3344486)*.
+Our paper *[Multitenant Containers as a Service (CaaS) for Clouds and Edge Clouds](https://doi.org/10.1109/ACCESS.2023.3344486)* introduced a native multitenancy framework for Kubernetes where tenants share a cluster, offering a more efficient alternative to the one-tenant-per-cluster model.
 
-→ [EdgeNet code (v1.0.0-alpha.5 release)](https://github.com/EdgeNet-project/edgenet-legacy-2024/releases/tag/v1.0.0-alpha.5)
+→ [EdgeNet code (v1.0.0-alpha.5 release)](https://github.com/EdgeNet-project/edgenet-legacy-2024/releases/tag/v1.0.0-alpha.5) (maintained in the EdgeNet-project organization)

--- a/profile/README.md
+++ b/profile/README.md
@@ -22,3 +22,9 @@ Our paper *[Zeph & Iris map the internet: A resilient reinforcement learning app
 
 → [Zeph code (v1.0.0 release)](https://github.com/dioptra-io/zeph/releases/tag/v1.0.0)
 → [Iris code (v1.0.0 release)](https://github.com/dioptra-io/iris/releases/tag/v1.0.0)
+
+### EdgeNet (IEEE Access 2023)
+
+Our paper *[Multitenant Containers as a Service (CaaS) for Clouds and Edge Clouds](https://doi.org/10.1109/ACCESS.2023.3344486)*.
+
+→ [EdgeNet code (v1.0.0-alpha.5 release)](https://github.com/EdgeNet-project/edgenet-legacy-2024/releases/tag/v1.0.0-alpha.5)


### PR DESCRIPTION
The page references Diamond-Miner and Zeph & Iris, and, even though EdgeNet is under a different organization, should reference it as well, I believe.